### PR TITLE
feat: 초기세팅 타입스크립트 커스텀 유틸리티 타입 추가 #67

### DIFF
--- a/utils/utilityTypes/NullablePick.ts
+++ b/utils/utilityTypes/NullablePick.ts
@@ -1,0 +1,3 @@
+type NullablePick<T, K extends keyof T> = {
+  [P in K]: T[P] | null;
+};

--- a/utils/utilityTypes/OptionalPick.ts
+++ b/utils/utilityTypes/OptionalPick.ts
@@ -1,0 +1,5 @@
+export type OptionalPick<T, K1 extends keyof T, K2 extends keyof T> = {
+  [P in K1]?: T[P];
+} & {
+  [P in K2]-?: T[P];
+};


### PR DESCRIPTION


# 작업 분류
- [x] 신규 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 기타

# 작업 개요
- 타입스크립트 커스텀 유틸리티 타입 추가

# 작업 상세 내용
- NullablePick, OptionalPick 추가

# 사용 예시
- NullablePick<BasicType, 'accessToken' | 'refreshToken'>;
- type UIInputLabelProps = OptionalPick<BasicType, 'className', 'text'>; // 두 번째 제너릭에 포함된 타입은 필수, 세 번째 제너릭은 옵션으로 구성됨

# 기타
- 
- Closes #1
