### PR TITLE
fix: 소셜 로그인 api 임시 url 수정

### DIFF
--- a/apis/auth.api.ts
+++ b/apis/auth.api.ts
@@ -15,7 +15,7 @@ export const oAuthLoginAPI = async ({
   data: Record<string, string>;
 }): Promise<LoginResponse> => {
   const response = await axiosInstance.post<LoginResponse>(
-    `/auth/signIn/${provider}`,
+    `https://winereview-api.vercel.app/8-4/auth/signIn/${provider}`,
     data
   );
   return response.data;


### PR DESCRIPTION
- team id 8-44 로 변경됨에 따른 oauth api 서버 오류로 oauth api 만 url 을 8-4 로 수정함

# 작업 분류
- [ ] 신규 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 기타

# 작업 개요
- 소셜 로그인 api 임시 url 수정

# 작업 상세 내용
- team id 8-44 로 변경됨에 따른 oauth api 서버 오류로 oauth api 만 url 을 8-4 로 수정함

